### PR TITLE
fix: Lambda 413 에러 해결 - PDF 용량 축소 (scale 2→1, PNG→JPEG)

### DIFF
--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -334,11 +334,12 @@ function ResultPage() {
       if (!target) throw new Error('콘텐츠를 찾을 수 없습니다');
 
       const canvas = await html2canvas(target, {
-        scale: 2,
+        scale: 1,
         useCORS: true,
         allowTaint: true,
         height: target.scrollHeight,
         windowHeight: target.scrollHeight,
+        logging: false,
       });
 
       setIsPrinting(false);
@@ -351,7 +352,7 @@ function ResultPage() {
       let y = 0;
       while (y < imgHeight) {
         if (y > 0) pdf.addPage();
-        pdf.addImage(canvas.toDataURL('image/png'), 'PNG', 0, -y, imgWidth, imgHeight);
+        pdf.addImage(canvas.toDataURL('image/jpeg', 0.75), 'JPEG', 0, -y, imgWidth, imgHeight);
         y += pageHeight;
       }
 


### PR DESCRIPTION
html2canvas scale을 2→1로 낮추고 PNG 대신 JPEG(75%) 포맷을 적용해 PDF 크기를 ~20MB에서 ~1.5MB로 줄임. AWS Lambda 페이로드 한도(6MB)를 초과해 발생하던 413 Request Entity Too Large 에러를 해결함.