### PR TITLE
ci/cd test용 추가 및 용량 문제 해결

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -2,15 +2,16 @@ name: Deploy Backend to Lambda
 
 on:
   push:
-    branches: [main]
     paths:
       - "backend/**"
       - "index.js"
+      - ".github/workflows/**"
   pull_request:
     branches: [main]
     paths:
       - "backend/**"
       - "index.js"
+      - ".github/workflows/**"
 
 jobs:
   build:
@@ -39,8 +40,56 @@ jobs:
       - name: 빌드 결과 확인
         run: ls -lh lambda.zip
 
-  deploy:
-    name: 람다 배포
+  deploy-staging:
+    name: 스테이징 배포 ($LATEST)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node.js 22 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: 프로덕션 의존성 패키지 설치
+        working-directory: backend
+        run: npm ci --omit=dev
+
+      - name: 배포용 압축 파일 생성
+        run: |
+          cd backend
+          zip -r ../lambda.zip . \
+             --exclude ".env" \
+             --exclude "*.git"
+
+      - name: AWS 자격 증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: S3로 압축 파일 업로드
+        run: |
+          aws s3 cp lambda.zip s3://${{ secrets.AWS_BUCKET }}/deploy-staging/lambda.zip
+
+      - name: $LATEST 업데이트 (staging alias 자동 반영)
+        run: |
+          aws lambda update-function-code \
+              --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+              --s3-bucket ${{ secrets.AWS_BUCKET }} \
+              --s3-key deploy-staging/lambda.zip
+
+      - name: 배포 완료 대기
+        run: |
+          aws lambda wait function-updated \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+
+  deploy-prod:
+    name: 프로덕션 배포 (prod alias)
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -117,3 +166,14 @@ jobs:
             --layers ${{ env.LAYER_ARN }}
           aws lambda wait function-updated \
             --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+
+      - name: 버전 publish 및 prod alias 업데이트
+        run: |
+          VERSION=$(aws lambda publish-version \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --query 'Version' \
+            --output text)
+          aws lambda update-alias \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --name prod \
+            --function-version $VERSION

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -6,12 +6,6 @@ on:
       - "backend/**"
       - "index.js"
       - ".github/workflows/**"
-  pull_request:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "index.js"
-      - ".github/workflows/**"
 
 jobs:
   build:

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -88,12 +88,14 @@ jobs:
 
       - name: 기존 Chromium Layer 조회 및 적용
         run: |
-          ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
-          LAYER_VERSION=$(aws lambda list-layer-versions \
-            --layer-name formflex-chromium \
-            --query 'LayerVersions[0].Version' \
+          LAYER_ARN=$(aws lambda get-function-configuration \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --query 'Layers[0].Arn' \
             --output text)
-          LAYER_ARN="arn:aws:lambda:${{ secrets.AWS_REGION }}:${ACCOUNT_ID}:layer/formflex-chromium:${LAYER_VERSION}"
+          if [ "$LAYER_ARN" = "None" ] || [ -z "$LAYER_ARN" ]; then
+            echo "Layer가 아직 없습니다. prod 배포 후 자동으로 붙습니다."
+            exit 0
+          fi
           aws lambda update-function-configuration \
             --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
             --layers $LAYER_ARN

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -7,6 +7,10 @@ on:
       - "index.js"
       - ".github/workflows/**"
 
+concurrency:
+  group: lambda-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
     name: 빌드 검증
@@ -79,6 +83,20 @@ jobs:
 
       - name: 배포 완료 대기
         run: |
+          aws lambda wait function-updated \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+
+      - name: 기존 Chromium Layer 조회 및 적용
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+          LAYER_VERSION=$(aws lambda list-layer-versions \
+            --layer-name formflex-chromium \
+            --query 'LayerVersions[0].Version' \
+            --output text)
+          LAYER_ARN="arn:aws:lambda:${{ secrets.AWS_REGION }}:${ACCOUNT_ID}:layer/formflex-chromium:${LAYER_VERSION}"
+          aws lambda update-function-configuration \
+            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --layers $LAYER_ARN
           aws lambda wait function-updated \
             --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
 


### PR DESCRIPTION

## CI/CD 스테이징 환경 구축 및 레이어 배포 수정

### 변경 사항

**Lambda Alias 기반 스테이징 환경 추가**
- Lambda 함수 하나에 `prod` / `staging` alias 두 개로 환경 분리
- feature 브랜치 push → `$LATEST` 업데이트 → `staging` alias로 테스트 가능
- main push → 버전 publish → `prod` alias가 해당 버전 고정

**워크플로우 트리거 개선**
- `.github/workflows/**` 경로 추가 → 워크플로우 파일 수정 시에도 CI/CD 트리거
- 기존: main push만 트리거 → 변경: 모든 브랜치 push 트리거

**Chromium 레이어 배포 방식 수정**
- 기존 `--zip-file` 직접 업로드 → S3 경유 업로드로 변경
- Lambda `PublishLayerVersion` 직접 업로드 70MB 제한 초과 문제 해결

### 배경
로컬 테스트가 Lambda 환경 의존성으로 어려워 브랜치 단위 스테이징 배포 환경 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated deployment infrastructure to separately manage staging and production releases with improved version control and Lambda function updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->