### PR TITLE
cd lambda layer 구조 문제 해결

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -140,8 +140,9 @@ jobs:
           cd chromium-layer/nodejs
           npm init -y
           npm install @sparticuz/chromium@147 puppeteer-core@24 --omit=dev
-          cd ../..
-          zip -r chromium-layer.zip chromium-layer/
+          cd ..
+          zip -r ../chromium-layer.zip nodejs/
+          cd ..
           echo "Layer zip size: $(ls -lh chromium-layer.zip | awk '{print $5}')"
 
       - name: Chromium Layer 배포


### PR DESCRIPTION

```
## 문제
Lambda Layer zip이 잘못된 디렉토리 구조로 생성되어 Runtime.ImportModuleError 발생
- 기존: chromium-layer/nodejs/node_modules/ → /opt/chromium-layer/nodejs/... (탐색 불가)

## 원인
zip 명령어를 프로젝트 루트에서 실행하여 chromium-layer/가 zip 최상위로 포함됨

## 수정
zip을 chromium-layer/ 내부에서 실행하여 nodejs/가 zip 최상위가 되도록 변경
- 수정: nodejs/node_modules/ → /opt/nodejs/... (정상 탐색)
```