### PR TITLE
pord 와 dev 파일 분리 수정

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -1,9 +1,11 @@
 name: Deploy Backend to Lambda
 
+# on : 언제 실행할지
 on:
   push:
     paths:
       - "backend/**"
+      #백엔드 폴더 안에 뭔가 바뀌면 이 파일을 실행해
       - "index.js"
       - ".github/workflows/**"
 
@@ -12,6 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  #bulid : 빌드 확인
   build:
     name: 빌드 검증
     runs-on: ubuntu-latest
@@ -27,6 +30,8 @@ jobs:
       - name: 프로덕션 의존성 패키지 설치
         working-directory: backend
         run: npm ci --omit=dev
+        # --omit=dev : package에는 두가지 있음. dependencies(express 실제 서비스) 와 devDependencies(개발할 때만 쓰는것)
+        # --omit=dev : 개발용 패키지까지 올리면 용량이 커지니까 ,--omit=dev를 통해 개발용 패키지는 제외하고 설치
 
       - name: 배포용 압축 파일 생성
         run: |
@@ -43,6 +48,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
+    # ref은 어느 브런치에 push 되었는지 물어보는거
+    # refs/heads/브런치 이름
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +84,7 @@ jobs:
       - name: $LATEST 업데이트 (staging alias 자동 반영)
         run: |
           aws lambda update-function-code \
-              --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+              --function-name formflex_dev \
               --s3-bucket ${{ secrets.AWS_BUCKET }} \
               --s3-key deploy-staging/lambda.zip \
               --architectures x86_64
@@ -85,35 +92,36 @@ jobs:
       - name: 배포 완료 대기
         run: |
           aws lambda wait function-updated \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+            --function-name formflex_dev
 
       - name: 기존 Chromium Layer 조회 및 적용
         run: |
           LAYER_ARN=$(aws lambda get-function-configuration \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --function-name formflex_dev \
             --query 'Layers[0].Arn' \
             --output text)
           if [ "$LAYER_ARN" = "None" ] || [ -z "$LAYER_ARN" ]; then
             echo "Layer가 아직 없습니다. prod 배포 후 자동으로 붙습니다."
             aws lambda update-function-configuration \
-              --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+              --function-name formflex_dev \
               --memory-size 2048 \
               --timeout 120
           else
             aws lambda update-function-configuration \
-              --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+              --function-name formflex_dev \
               --memory-size 2048 \
               --timeout 120 \
               --layers $LAYER_ARN
           fi
           aws lambda wait function-updated \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+            --function-name formflex_dev
 
   deploy-prod:
     name: 프로덕션 배포 (prod alias)
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    #브런치가 main 브런치일 때 실제 배포 시작
 
     steps:
       - uses: actions/checkout@v4
@@ -171,7 +179,7 @@ jobs:
       - name: S3에서 람다 함수 배포
         run: |
           aws lambda update-function-code \
-              --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+              --function-name formflex \
               --s3-bucket ${{ secrets.AWS_BUCKET }} \
               --s3-key deploy/lambda.zip \
               --architectures x86_64
@@ -179,26 +187,26 @@ jobs:
       - name: 배포 완료 대기
         run: |
           aws lambda wait function-updated \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+            --function-name formflex
 
       - name: Lambda 핸들러 및 Layer 설정
         run: |
           aws lambda update-function-configuration \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --function-name formflex \
             --handler handler.handler \
             --memory-size 2048 \
             --timeout 120 \
             --layers ${{ env.LAYER_ARN }}
           aws lambda wait function-updated \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }}
+            --function-name formflex
 
       - name: 버전 publish 및 prod alias 업데이트
         run: |
           VERSION=$(aws lambda publish-version \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --function-name formflex \
             --query 'Version' \
             --output text)
           aws lambda update-alias \
-            --function-name ${{ secrets.AWS_LAMBDA_FUNCTION_NAME }} \
+            --function-name formflex \
             --name prod \
             --function-version $VERSION


### PR DESCRIPTION
## 변경 사항

Lambda 함수를 환경별로 분리 배포하도록 CI/CD 파이프라인 수정

### 기존
- `AWS_LAMBDA_FUNCTION_NAME` 시크릿 하나로 staging/prod 모두 같은 람다에 배포

### 변경 후
| 브랜치 | 배포 대상 |
|--------|-----------|
| main 외 브랜치 push | `formflex_dev` 람다 |
| main 브랜치 merge | `formflex` 람다 |

### 수정 내용
- `deploy-staging` 잡: `--function-name` → `formflex_dev` 로 하드코딩
- `deploy-prod` 잡: `--function-name` → `formflex` 로 하드코딩
- `AWS_LAMBDA_FUNCTION_NAME` 시크릿 더 이상 사용 안 함

---

## 배운 것 (CI/CD 입문)

이번 작업을 통해 GitHub Actions 파이프라인 구조를 처음 이해했습니다.

## 배운 것 (CI/CD 입문)

이번 작업을 통해 GitHub Actions 파이프라인 구조를 처음 이해했습니다.

- `on: push` → 코드가 push되면 워크플로 자동 실행

- `paths` 필터 → 백엔드 파일이 바뀔 때만 실행, 불필요한 배포 방지
  - 프론트엔드 코드만 바꿨는데 백엔드 람다가 재배포되면 낭비이기 때문

- `needs: build` → 빌드가 성공해야만 배포 단계로 진행
  - 빌드가 실패하면 배포 자체가 막힘, 깨진 코드가 서버에 올라가는 것을 방지

- `if: github.ref` → 브랜치 이름을 보고 dev/prod 중 어디에 배포할지 결정
  - `github.ref != 'refs/heads/main'` → main이 **아닌** 브랜치에 push하면 `formflex_dev` 람다로 배포
  - `github.ref == 'refs/heads/main'` → main 브랜치에 merge되면 `formflex` 람다로 배포
  - 쉽게 말하면: 개발 중인 브랜치는 dev 서버, 완성된 코드만 prod 서버에 올라감

- `--omit=dev` → `package.json`에는 패키지가 두 종류 있음
  - `dependencies` → 실제 서비스 실행에 필요한 패키지 (express 등)
  - `devDependencies` → 개발할 때만 쓰는 패키지 (eslint, jest 등)
  - 람다에 올릴 때 개발용 패키지까지 올리면 용량만 커지기 때문에 `--omit=dev`로 개발용 패키지는 제외하고 설치

파이프라인 전체 흐름:
 push 발생 → 빌드 검증 → main이면 formflex / 아니면 formflex_dev 에 배포

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow documentation with detailed inline comments explaining trigger conditions and variable references.
  * Standardized backend deployment configuration across staging and production environments with explicit function identifiers.
  * Improved Lambda deployment steps with clearer function name specifications for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ssojungg/formflex/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->