### PR TITLE
dev 버전에도 chromium 기능 추가

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -94,14 +94,14 @@ jobs:
           aws lambda wait function-updated \
             --function-name formflex-dev
 
-      - name: 기존 Chromium Layer 조회 및 적용
+      - name: Chromium Layer 조회 및 적용
         run: |
-          LAYER_ARN=$(aws lambda get-function-configuration \
-            --function-name formflex-dev \
-            --query 'Layers[0].Arn' \
+          LAYER_ARN=$(aws lambda list-layer-versions \
+            --layer-name formflex-chromium \
+            --query 'LayerVersions[0].LayerVersionArn' \
             --output text)
           if [ "$LAYER_ARN" = "None" ] || [ -z "$LAYER_ARN" ]; then
-            echo "Layer가 아직 없습니다. prod 배포 후 자동으로 붙습니다."
+            echo "Chromium Layer가 없습니다. prod 배포를 먼저 실행해주세요."
             aws lambda update-function-configuration \
               --function-name formflex-dev \
               --memory-size 2048 \


### PR DESCRIPTION

## 📋 PR 개요

`formflex-dev` Lambda에 Chromium Layer가 자동으로 연결되지 않는 문제 수정.
`deploy-staging` 레이어 조회 방식을 변경하여 브랜치 push 시 자동으로 붙도록 개선.

---

## 🔍 문제 원인 분석

### 기존 코드의 문제점

```bash
LAYER_ARN=$(aws lambda get-function-configuration \
  --function-name formflex-dev \
  --query 'Layers[0].Arn' \
  --output text)
```

`formflex-dev`는 신규 생성된 Lambda라 처음엔 레이어가 없음.
→ `LAYER_ARN`이 `None`으로 반환됨
→ if 조건에 걸려서 레이어 없이 배포됨
→ Chromium 기능 사용 불가

### 왜 Chromium Layer가 필요한가

백엔드 `sendPdfReport.js`에서 `@sparticuz/chromium` + `puppeteer-core`를 사용.
설문 응답이 임계값에 도달하면 Puppeteer로 결과 페이지를 PDF 변환 후 이메일 전송하는 핵심 기능이 이 레이어에 의존함.
레이어 없이도 try-catch로 앱이 터지진 않지만, **dev 환경에서 PDF 이메일 전송 기능을 테스트할 수 없는 상태**였음.

---

## ✅ 해결 방법

```bash
LAYER_ARN=$(aws lambda list-layer-versions \
  --layer-name formflex-chromium \
  --query 'LayerVersions[0].LayerVersionArn' \
  --output text)
```

`formflex-chromium` 레이어는 `deploy-prod` 실행 시 매번 새 버전으로 배포됨.
`list-layer-versions`로 항상 최신 버전 ARN을 가져와서 `formflex-dev`에 연결.

---

## 🔄 변경 사항

| | 기존 | 변경 후 |
|--|------|---------|
| 레이어 조회 방법 | `get-function-configuration` | `list-layer-versions` |
| 신규 Lambda 동작 | 레이어 없이 배포 | 항상 최신 Chromium Layer 연결 |

---

## 🏗️ 인프라 구조

```
deploy-prod (main 브랜치)
  └── formflex-chromium Layer 새 버전 생성 및 배포
  └── formflex-prod에 해당 Layer 연결

deploy-staging (기타 브랜치)
  └── formflex-chromium 최신 버전 조회 (새로 만들지 않음, 재사용)
  └── formflex-dev에 해당 Layer 연결
```

Layer를 prod에서 한 번만 만들고, dev는 그걸 재사용하는 구조.
불필요한 빌드 시간 없이 효율적으로 동일한 환경 유지 가능.

---

## 📝 배운 점

- `get-function-configuration`: 특정 Lambda에 현재 붙어있는 레이어 조회
- `list-layer-versions`: Lambda Layer 레지스트리에서 버전 목록 조회
- 신규 Lambda는 레이어가 없으므로 함수 기준 조회가 아닌 **레이어 레지스트리 기준 조회**로 해야 함
- prod와 dev가 **동일한 Chromium Layer 버전**을 공유하므로 환경 차이로 인한 버그 방지 가능