### PR TITLE
N+1 쿼리 및 인메모리 페이지네이션 성능 개선

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -76,10 +76,10 @@ jobs:
         run: |
           aws s3 cp lambda.zip s3://${{ secrets.AWS_BUCKET }}/deploy-staging/lambda.zip
 
-      - name: formflex_dev 람다 배포
+      - name: formflex-dev 람다 배포
         run: |
           aws lambda update-function-code \
-              --function-name formflex_dev \
+              --function-name formflex-dev \
               --s3-bucket ${{ secrets.AWS_BUCKET }} \
               --s3-key deploy-staging/lambda.zip \
               --architectures x86_64
@@ -87,7 +87,7 @@ jobs:
       - name: 배포 완료 대기
         run: |
           aws lambda wait function-updated \
-            --function-name formflex_dev
+            --function-name formflex-dev
 
   deploy-prod:
     name: 프로덕션 배포 (prod alias)

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -5,16 +5,15 @@ on:
   push:
     paths:
       - "backend/**"
-      #백엔드 폴더 안에 뭔가 바뀌면 이 파일을 실행해
       - "index.js"
       - ".github/workflows/**"
+      - "serverless.yml"
 
 concurrency:
   group: lambda-deploy
   cancel-in-progress: false
 
 jobs:
-  #bulid : 빌드 확인
   build:
     name: 빌드 검증
     runs-on: ubuntu-latest
@@ -30,8 +29,6 @@ jobs:
       - name: 프로덕션 의존성 패키지 설치
         working-directory: backend
         run: npm ci --omit=dev
-        # --omit=dev : package에는 두가지 있음. dependencies(express 실제 서비스) 와 devDependencies(개발할 때만 쓰는것)
-        # --omit=dev : 개발용 패키지까지 올리면 용량이 커지니까 ,--omit=dev를 통해 개발용 패키지는 제외하고 설치
 
       - name: 배포용 압축 파일 생성
         run: |
@@ -48,8 +45,55 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
-    # ref은 어느 브런치에 push 되었는지 물어보는거
-    # refs/heads/브런치 이름
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node.js 22 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: 백엔드 프로덕션 의존성 설치
+        working-directory: backend
+        run: npm ci --omit=dev
+
+      - name: 배포용 압축 파일 생성
+        run: |
+          cd backend
+          zip -r ../lambda.zip . \
+             --exclude ".env" \
+             --exclude "*.git"
+
+      - name: AWS 자격 증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: S3로 압축 파일 업로드
+        run: |
+          aws s3 cp lambda.zip s3://${{ secrets.AWS_BUCKET }}/deploy-staging/lambda.zip
+
+      - name: formflex_dev 람다 배포
+        run: |
+          aws lambda update-function-code \
+              --function-name formflex_dev \
+              --s3-bucket ${{ secrets.AWS_BUCKET }} \
+              --s3-key deploy-staging/lambda.zip \
+              --architectures x86_64
+
+      - name: 배포 완료 대기
+        run: |
+          aws lambda wait function-updated \
+            --function-name formflex_dev
+
+  deploy-prod:
+    name: 프로덕션 배포 (prod alias)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4
@@ -75,78 +119,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: S3로 압축 파일 업로드
-        run: |
-          aws s3 cp lambda.zip s3://${{ secrets.AWS_BUCKET }}/deploy-staging/lambda.zip
-
-      - name: $LATEST 업데이트 (staging alias 자동 반영)
-        run: |
-          aws lambda update-function-code \
-              --function-name formflex-dev \
-              --s3-bucket ${{ secrets.AWS_BUCKET }} \
-              --s3-key deploy-staging/lambda.zip \
-              --architectures x86_64
-
-      - name: 배포 완료 대기
-        run: |
-          aws lambda wait function-updated \
-            --function-name formflex-dev
-
-      - name: Chromium Layer 조회 및 적용
-        run: |
-          LAYER_ARN=$(aws lambda list-layer-versions \
-            --layer-name formflex-chromium \
-            --query 'LayerVersions[0].LayerVersionArn' \
-            --output text)
-          if [ "$LAYER_ARN" = "None" ] || [ -z "$LAYER_ARN" ]; then
-            echo "Chromium Layer가 없습니다. prod 배포를 먼저 실행해주세요."
-            aws lambda update-function-configuration \
-              --function-name formflex-dev \
-              --memory-size 2048 \
-              --timeout 120
-          else
-            aws lambda update-function-configuration \
-              --function-name formflex-dev \
-              --memory-size 2048 \
-              --timeout 120 \
-              --layers $LAYER_ARN
-          fi
-          aws lambda wait function-updated \
-            --function-name formflex-dev
-
-  deploy-prod:
-    name: 프로덕션 배포 (prod alias)
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    #브런치가 main 브런치일 때 실제 배포 시작
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Node.js 22 설정
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: 프로덕션 의존성 패키지 설치
-        working-directory: backend
-        run: npm ci --omit=dev
-
-      - name: 배포용 압축 파일 생성
-        run: |
-          cd backend
-          zip -r ../lambda.zip . \
-             --exclude ".env" \
-             --exclude "*.git"
-
-      - name: AWS 자격 증명 설정
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Chromium Lambda Layer 생성
@@ -179,7 +151,7 @@ jobs:
       - name: S3에서 람다 함수 배포
         run: |
           aws lambda update-function-code \
-              --function-name formflex-prod \
+              --function-name formflex \
               --s3-bucket ${{ secrets.AWS_BUCKET }} \
               --s3-key deploy/lambda.zip \
               --architectures x86_64
@@ -187,30 +159,26 @@ jobs:
       - name: 배포 완료 대기
         run: |
           aws lambda wait function-updated \
-            --function-name formflex-prod
+            --function-name formflex
 
       - name: Lambda 핸들러 및 Layer 설정
         run: |
           aws lambda update-function-configuration \
-            --function-name formflex-prod \
+            --function-name formflex \
             --handler handler.handler \
             --memory-size 2048 \
             --timeout 120 \
             --layers ${{ env.LAYER_ARN }}
           aws lambda wait function-updated \
-            --function-name formflex-prod
+            --function-name formflex
 
       - name: 버전 publish 및 prod alias 업데이트
         run: |
           VERSION=$(aws lambda publish-version \
-            --function-name formflex-prod \
+            --function-name formflex \
             --query 'Version' \
             --output text)
-          aws lambda create-alias \
-            --function-name formflex-prod \
-            --name prod \
-            --function-version $VERSION 2>/dev/null || \
           aws lambda update-alias \
-            --function-name formflex-prod \
+            --function-name formflex \
             --name prod \
             --function-version $VERSION

--- a/backend/controller/answerSave.js
+++ b/backend/controller/answerSave.js
@@ -8,20 +8,29 @@ const createAnswer = async (req, res) => {
   const surveyId = req.params.id;
   try {
     const { userId, questions } = req.body;
+    const questionIds = questions.map((q) => q.questionId);
+    const allObjIds = questions.flatMap((q) => q.objContent || []);
+
+    const [questionDatas, choices, existingAnswers] = await Promise.all([
+      Question.findAll({where: {id: questionIds}, transaction: t}),
+      Choice.findAll({where: {id: allObjIds}, transaction: t}),
+      Answer.findAll({where:{questionId: questionIds,userId},transaction: t}),
+    ]);
+
+    const questionMap = new Map(questionDatas.map((q) => [q.id, q]));
+    const choiceMap = new Map(choices.map((c) => [c.id,c]));
+    const existingSet = new Set(existingAnswers.filter((a) => a.objContent).map((a)=> `${a.questionId}_${a.objContent}`));
     const survey = await Survey.findByPk(surveyId);
     if (!survey) {
       await t.rollback();
       return res.status(400).json({ message: '설문이 존재하지 않습니다.' });
     }
     for (const question of questions) {
-      // 질문의 타입을 확인
-      const questionData = await Question.findByPk(question.questionId, {
-        transaction: t,
-      });
+      const questionData = questionMap.get(question.questionId);
       if (!questionData) {
         await t.rollback();
         return res.status(400).json({
-          message: `Question with ID ${question.questionId} not found`,
+          message: `Question with Id ${question.questionId} not found`,
         });
       }
       if (questionData.surveyId != surveyId) {
@@ -42,30 +51,21 @@ const createAnswer = async (req, res) => {
       ) {
         // objContent의 각 요소에 대한 별도의 Answer 레코드 생성
         for (const objContentItem of question.objContent) {
-          const option = await Choice.findByPk(objContentItem, {
-            transaction: t,
-          });
-          if (!option) {
+          const option = choiceMap.get(objContentItem);
+          if(!option) {
             await t.rollback();
-            return res
-              .status(400)
-              .json({ message: `Choice with ID ${objContentItem} not found` });
+            return res.status(400).json({
+              message: `Choice with Id ${objContentItem} not found`
+            });
           }
           if (option.questionId != question.questionId) {
             await t.rollback();
-            return res
-              .status(404)
-              .json({ message: `질문에 해당 선택지가 없습니다.` });
+            return res.status(404).json({
+              message: `질문에 해당 선택지가 없습니다.`
+            });
           }
           // 같은 레코드 있는지 확인
-          const existingAnswer = await Answer.findOne({
-            where: {
-              questionId: question.questionId,
-              userId: userId,
-              objContent: objContentItem,
-            },
-            transaction: t,
-          });
+          const existingAnswer = existingSet.has(`${question.questionId}_${objContentItem}`);
           // 체크박스의 경우 중복 허용
           if (!existingAnswer && questionData.type === 'CHECKBOX') {
             await Answer.create(
@@ -118,17 +118,9 @@ const createAnswer = async (req, res) => {
         }
       } else {
         // SUBJECTIVE_QUESTION
-        const existingAnswer = await Answer.findOne({
-          where: {
-            questionId: question.questionId,
-            userId: userId,
-            subContent: question.subContent || null,
-            objContent: null,
-          },
-          transaction: t,
-        });
+        const existingAnswerSub = existingAnswers.find((a) => a.questionId === question.questionId && a.subContent === (question.subContent || null));
 
-        if (!existingAnswer) {
+        if (!existingAnswerSub) {
           await Answer.create(
             {
               questionId: question.questionId,

--- a/backend/controller/formAllUser.js
+++ b/backend/controller/formAllUser.js
@@ -1,8 +1,7 @@
 const { performance } = require('perf_hooks');
-const { fn, col, literal, where } = require('sequelize');
+const { col, literal } = require('sequelize');
 const { Survey, Answer, Question } = require('../models');
 const { surveyTitleSearch } = require('./surveyTitleSearch');
-const { group } = require('console');
 
 const getUserSurveys = async (req, res) => {
   const start = performance.now();
@@ -11,8 +10,6 @@ const getUserSurveys = async (req, res) => {
     const userId = req.params.id;
     const pageLimit = req.query.limit;
     const page = req.query.page;
-    const startIndex = (page - 1) * pageLimit;
-    const endIndex = startIndex + pageLimit;
     const title = req.query.title;
 
     if (!title) {
@@ -27,6 +24,8 @@ const getUserSurveys = async (req, res) => {
           'open',
           'emailReportThreshold',
         ],
+        limit: Number(pageLimit),
+        offset: (Number(page) - 1) * Number(pageLimit),
       });
       queryCount++;
       const surveyIds = surveys.map((s) => s.id);
@@ -60,7 +59,7 @@ const getUserSurveys = async (req, res) => {
         attendCount: countMap[survey.id] || 0,
         emailReportThreshold: survey.emailReportThreshold || null,
       }));
-      queryCount++;
+
       if ('attendCount' in req.query) {
         preResult.sort((a, b) => b.attendCount - a.attendCount);
       } else if ('deadline' in req.query) {
@@ -72,7 +71,7 @@ const getUserSurveys = async (req, res) => {
       const totalCount = await Survey.count({ where: { userId: userId } });
       queryCount++;
       const totalPages = Math.ceil(totalCount / pageLimit);
-      const currentPageData = preResult.slice(startIndex, endIndex);
+      const currentPageData = preResult;
       const end = performance.now();
       console.log(`=============`);
       console.log(
@@ -80,9 +79,11 @@ const getUserSurveys = async (req, res) => {
       );
       console.log(`[수정 후(폼 모아보기)] 총 쿼리 횟수: ${queryCount}번`);
       console.log(`==============`);
-      res
-        .status(200)
-        .json({ surveys: currentPageData, totalPages: totalPages, totalCount: totalCount });
+      res.status(200).json({
+        surveys: currentPageData,
+        totalPages: totalPages,
+        totalCount: totalCount,
+      });
     } else {
       const selectSurveys = await Survey.findAll({
         where: { userId: userId },

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -32,6 +32,7 @@ const { generateChoices, generateSummary } = require('./controller/gemini');
 const { Question, Answer, Choice } = require('./models');
 const { sequelize } = require('./models');
 const Excel = require('exceljs');
+//const { Models } = require('openai/resources/models.mjs');
 
 let isDbConnected = false;
 
@@ -125,7 +126,7 @@ function callController(controllerFn, req, corsHeaders) {
 }
 
 // 엑셀 다운도르 헨들러
-async function handleExcelDownload(req) {
+async function handleExcelDownload(req, corsHeaders) {
   const surveyId = req.params.surveyId;
   const workbook = new Excel.Workbook();
   const worksheet = workbook.addWorksheet('설문 응답');
@@ -147,22 +148,26 @@ async function handleExcelDownload(req) {
       ...header.slice(1).map(() => ({ width: 45 })),
     ];
 
-    const userData = {};
-    for (const question of questions) {
-      const answers = await Answer.findAll({
-        where: { questionId: question.id },
-      });
-      for (const answer of answers) {
-        const userId = answer.userId;
-        if (!userData[userId]) userData[userId] = {};
-        if (!userData[userId][question.id]) userData[userId][question.id] = [];
+    const questionIds = questions.map((q) => q.id);
 
-        if (answer.objContent) {
-          const choice = await Choice.findByPk(answer.objContent);
-          userData[userId][question.id].push(choice ? choice.option : 'N/A');
-        } else {
-          userData[userId][question.id].push(answer.subContent || 'N/A');
-        }
+    const answers = await Answer.findAll({
+      where: { questionId: questionIds },
+    });
+
+    const choiceIds = [...new Set(answers.filter((a) => a.objContent).map((a) => a.objContent))];
+    const choices = choiceIds.length ? await Choice.findAll({ where: { id: choiceIds } }) : [];
+    const choiceMap = new Map(choices.map((c) => [c.id, c.option]));
+
+    const userData = {};
+    for (const answer of answers) {
+      const uid = answer.userId;
+      if (!userData[uid]) userData[uid] = {};
+      if (!userData[uid][answer.questionId]) userData[uid][answer.questionId] = [];
+
+      if (answer.objContent) {
+        userData[uid][answer.questionId].push(choiceMap.get(answer.objContent) || 'N/A');
+      } else {
+        userData[uid][answer.questionId].push(answer.subContent || 'N/A');
       }
     }
 
@@ -324,7 +329,7 @@ exports.handler = async (event) => {
   //엑셀 다운로드 (별도 처리)
   const excelParams = matchPath('/api/surveys/:surveyId/download', path);
   if (method === 'GET' && excelParams) {
-    return handleExcelDownload(createReq(event, excelParams));
+    return handleExcelDownload(createReq(event, excelParams), corsHeaders);
   }
 
   //라우트 매칭


### PR DESCRIPTION
---

## PR: N+1 쿼리 및 인메모리 페이지네이션 성능 개선

### 개요
답변 저장, 엑셀 다운로드, 폼 목록 조회에서 발생하던 N+1 쿼리 문제와 인메모리 페이지네이션을 수정했습니다.

---

### 1. 엑셀 다운로드 N×M 쿼리 제거 (`handler.js`)

**문제**
```js
for (const question of questions) {
  const answers = await Answer.findAll(...)   // 질문 N개마다 쿼리
  for (const answer of answers) {
    const choice = await Choice.findByPk(...) // 답변 M개마다 쿼리
  }
}
// 질문 10개, 답변 100개 → 최대 1 + 10 + 1000 = 1011번 쿼리
```
이중 루프 안에서 DB 조회가 반복되는 전형적인 N×M 패턴이었습니다. 또한 `corsHeaders`가 함수 스코프 외부에서 참조되어 런타임 에러가 발생할 수 있는 버그도 있었습니다.

**수정**
- `questionIds` 배열로 `Answer` 전체를 한 번에 조회
- 객관식 답변의 `objContent`(choiceId)를 Set으로 중복 제거 후 `Choice` 한 번에 조회
- `Map`으로 변환해 루프 내에서 O(1) 참조
- `corsHeaders`를 파라미터로 전달하도록 수정

**기대효과**
쿼리 횟수가 데이터 크기에 무관하게 최대 3번으로 고정됩니다.

---

### 2. 답변 저장 루프 내 N+1 제거 (`answerSave.js`)

**문제**
```js
for (const question of questions) {
  await Question.findByPk(...)  // 질문마다 쿼리
  for (const objContentItem of question.objContent) {
    await Choice.findByPk(...)  // 선택지마다 쿼리
    await Answer.findOne(...)   // 선택지마다 쿼리
  }
}
// 질문 5개 × 선택지 3개 → 최대 5 × 3 × 2 = 30번 이상 쿼리
```

**수정**
- 루프 시작 전 `Promise.all`로 Question, Choice, Answer를 배치 조회
- `Map`, `Set`으로 변환 후 루프 안에서는 DB 호출 없이 메모리 참조만 사용
- 주관식 중복 체크도 `existingAnswers.find()`로 대체

**기대효과**
루프 전 고정 3번의 배치 쿼리로 처리되어 질문·선택지 수가 늘어도 쿼리 수가 증가하지 않습니다.

---

### 3. 인메모리 페이지네이션 → DB 페이지네이션 (`formAllUser.js`)

**문제**
```js
// 전체 데이터를 가져온 뒤 JS에서 자름
const surveys = await Survey.findAll({ where: { userId } }) // 전체 조회
const currentPageData = preResult.slice(startIndex, endIndex)
```
설문 수가 늘어날수록 불필요한 데이터를 전부 메모리에 올리는 구조였습니다.

추가로 `surveys.map()` 직후에 `queryCount++`가 실행되고 있었는데, `map()`은 DB 쿼리가 아니므로 쿼리 횟수 집계가 부정확했습니다.

**수정**
- `Survey.findAll`에 `limit`, `offset` 추가해 DB 레벨에서 페이지 단위 조회
- `slice()` 제거, 사용하지 않는 `startIndex`, `endIndex` 변수 제거
- `map()` 이후 잘못된 `queryCount++` 제거

**기대효과**
항상 페이지 크기만큼만 데이터를 조회해 메모리 사용량과 응답 속도가 개선됩니다.

---

### 4. CI/CD 파이프라인 정리 (`depoly.yml`)

- Lambda 함수명 실제 배포 환경에 맞게 통일 (`formflex-dev` → `formflex_dev`, `formflex-prod` → `formflex`)
- staging 배포에서 불필요한 Chromium Layer 조회 단계 제거
- `serverless.yml` 변경 시에도 CI 트리거되도록 paths에 추가
- 불필요한 인라인 주석 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Form browsing optimized for faster load times through improved pagination
  * Answer processing made more efficient by reducing redundant database queries
  * Excel export functionality streamlined for better performance

* **Chores**
  * AWS Lambda deployment workflow enhanced for improved staging and production environment handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ssojungg/formflex/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->