### PR TITLE
fix: API Gateway 경로 prefix 불일치 및 CI/CD 배포 대상 함수 수정

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -151,7 +151,7 @@ jobs:
       - name: S3에서 람다 함수 배포
         run: |
           aws lambda update-function-code \
-              --function-name formflex \
+              --function-name formflex-prod \
               --s3-bucket ${{ secrets.AWS_BUCKET }} \
               --s3-key deploy/lambda.zip \
               --architectures x86_64
@@ -159,26 +159,26 @@ jobs:
       - name: 배포 완료 대기
         run: |
           aws lambda wait function-updated \
-            --function-name formflex
+            --function-name formflex-prod
 
       - name: Lambda 핸들러 및 Layer 설정
         run: |
           aws lambda update-function-configuration \
-            --function-name formflex \
+            --function-name formflex-prod \
             --handler handler.handler \
             --memory-size 2048 \
             --timeout 120 \
             --layers ${{ env.LAYER_ARN }}
           aws lambda wait function-updated \
-            --function-name formflex
+            --function-name formflex-prod
 
       - name: 버전 publish 및 prod alias 업데이트
         run: |
           VERSION=$(aws lambda publish-version \
-            --function-name formflex \
+            --function-name formflex-prod \
             --query 'Version' \
             --output text)
           aws lambda update-alias \
-            --function-name formflex \
+            --function-name formflex-prod \
             --name prod \
             --function-version $VERSION

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -23,10 +23,17 @@ const { showAllSurveys } = require('./controller/showAllSurveys');
 const { deleteSurveyAndRelatedData } = require('./controller/surveyDelete');
 const { createAnswer } = require('./controller/answerSave');
 const { getUrl } = require('./controller/getSurveyUrl');
-const { sendSurveyEmailWithSurveyId, sendReportEmail } = require('./controller/urlShare');
+const {
+  sendSurveyEmailWithSurveyId,
+  sendReportEmail,
+} = require('./controller/urlShare');
 const { getAnswerByuserId } = require('./controller/answerReadByuserId');
 const { getResultsByResponses } = require('./controller/getResultsByRes');
-const { generatePresignedUploadUrl, getFileFromS3, deleteFileFromS3 } = require('./controller/imageUpload');
+const {
+  generatePresignedUploadUrl,
+  getFileFromS3,
+  deleteFileFromS3,
+} = require('./controller/imageUpload');
 const { generateChoices, generateSummary } = require('./controller/gemini');
 
 const { Question, Answer, Choice } = require('./models');
@@ -41,9 +48,10 @@ function getCorsHeaders(event) {
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Methods': 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type,Accept,X-Requested-With,remember-me,Authorization',
+    'Access-Control-Allow-Headers':
+      'Content-Type,Accept,X-Requested-With,remember-me,Authorization',
     'Access-Control-Allow-Credentials': 'true',
-    'Vary': 'Origin',
+    Vary: 'Origin',
   };
 }
 
@@ -154,18 +162,25 @@ async function handleExcelDownload(req, corsHeaders) {
       where: { questionId: questionIds },
     });
 
-    const choiceIds = [...new Set(answers.filter((a) => a.objContent).map((a) => a.objContent))];
-    const choices = choiceIds.length ? await Choice.findAll({ where: { id: choiceIds } }) : [];
+    const choiceIds = [
+      ...new Set(answers.filter((a) => a.objContent).map((a) => a.objContent)),
+    ];
+    const choices = choiceIds.length
+      ? await Choice.findAll({ where: { id: choiceIds } })
+      : [];
     const choiceMap = new Map(choices.map((c) => [c.id, c.option]));
 
     const userData = {};
     for (const answer of answers) {
       const uid = answer.userId;
       if (!userData[uid]) userData[uid] = {};
-      if (!userData[uid][answer.questionId]) userData[uid][answer.questionId] = [];
+      if (!userData[uid][answer.questionId])
+        userData[uid][answer.questionId] = [];
 
       if (answer.objContent) {
-        userData[uid][answer.questionId].push(choiceMap.get(answer.objContent) || 'N/A');
+        userData[uid][answer.questionId].push(
+          choiceMap.get(answer.objContent) || 'N/A',
+        );
       } else {
         userData[uid][answer.questionId].push(answer.subContent || 'N/A');
       }
@@ -215,8 +230,16 @@ const routes = [
   { method: 'GET', path: '/api/users/:id', handler: getMyInfo },
 
   // Gemini
-  { method: 'POST', path: '/api/surveys/gemini/choices', handler: generateChoices },
-  { method: 'POST', path: '/api/surveys/gemini/summary', handler: generateSummary },
+  {
+    method: 'POST',
+    path: '/api/surveys/gemini/choices',
+    handler: generateChoices,
+  },
+  {
+    method: 'POST',
+    path: '/api/surveys/gemini/summary',
+    handler: generateSummary,
+  },
 
   //survey
   {
@@ -277,12 +300,16 @@ const routes = [
     path: '/api/surveys/:id/report-email',
     handler: async (req, res) => {
       const { email, surveyTitle, s3Key } = req.body;
-      if (!email) return res.status(400).json({ message: 'email 필드가 필요합니다' });
-      if (!s3Key) return res.status(400).json({ message: 's3Key 필드가 필요합니다' });
+      if (!email)
+        return res.status(400).json({ message: 'email 필드가 필요합니다' });
+      if (!s3Key)
+        return res.status(400).json({ message: 's3Key 필드가 필요합니다' });
       try {
         const pdfBuffer = await getFileFromS3(s3Key);
         const result = await sendReportEmail(email, pdfBuffer, surveyTitle);
-        deleteFileFromS3(`https://${process.env.AWS_BUCKET}.s3.${process.env.AWS_S3_REGION}.amazonaws.com/${s3Key}`).catch(() => {});
+        deleteFileFromS3(
+          `https://${process.env.AWS_BUCKET}.s3.${process.env.AWS_S3_REGION}.amazonaws.com/${s3Key}`,
+        ).catch(() => {});
         res.status(200).json(result);
       } catch (error) {
         res.status(500).json({ message: error.message || '서버 오류 발생' });
@@ -313,7 +340,8 @@ const routes = [
 //메인 lambda핸들러
 exports.handler = async (event) => {
   const method = event.requestContext?.http?.method || event.httpMethod;
-  const path = event.rawPath || event.path;
+  const rawPath = event.rawPath || event.path;
+  const path = rawPath.replace(/^\/formflex-[^/]+/, '');
   const corsHeaders = getCorsHeaders(event);
   //CORS preflight
   if (method === 'OPTIONS') {

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -341,7 +341,7 @@ const routes = [
 exports.handler = async (event) => {
   const method = event.requestContext?.http?.method || event.httpMethod;
   const rawPath = event.rawPath || event.path;
-  const path = rawPath.replace(/^\/formflex-[^/]+/, '');
+  const path = rawPath.replace(/^.*\/formflex-[^/]+/, '');
   const corsHeaders = getCorsHeaders(event);
   //CORS preflight
   if (method === 'OPTIONS') {


### PR DESCRIPTION
## 버그 리포트 및 수정 내역

운영 환경(prod) 전체 API가 동작하지 않던 문제의 원인과 수정 내역입니다.

---

## 버그 1: handler.js 경로 prefix 불일치 → 전체 API 404

### 원인
API Gateway 리소스 경로가 `/formflex-prod`로 설정되어 있어,
Lambda가 실제로 수신하는 `rawPath`는 다음과 같았음:

```
/formflex-prod/api/users/login
```

그러나 `handler.js`의 라우트 목록은 `/api/...` 기준으로만 정의되어 있어
어떤 라우트도 매칭되지 않음 → 모든 요청 404 반환.

### 수정
`handler.js` 344번째 줄에서 `rawPath`에서 `/formflex-{stage}` prefix를 제거 후 라우팅:

```js
// 수정 전
const rawPath = event.rawPath || event.path;
const path = rawPath.replace(/^\/formflex-[^/]+/, '');

// 수정 후
const rawPath = event.rawPath || event.path || '';
const path = rawPath.replace(/^.*\/formflex-[^/]+/, '');
```

`^.*` 추가 이유: 실제 `rawPath`는 `/formflex-prod/...` 뿐 아니라
스테이지 이름이 붙어 `/default/formflex-prod/...` 형태로 오기도 함.

---

## 버그 2: depoly.yml 배포 대상 함수명 오류 → 최신 코드 미반영

### 원인
`.github/workflows/depoly.yml`의 prod 배포 스텝이
`--function-name formflex`로 되어 있어,
API Gateway와 연결된 `formflex-prod` 함수가 아닌 다른 함수에 배포됨.
결과적으로 `formflex-prod`는 약 1주일 전 코드로 계속 실행되고 있었음.

### 수정
prod 배포 스텝 함수명 변경:

```yaml
# 수정 전
--function-name formflex

# 수정 후
--function-name formflex-prod
```

---

## 버그 3: API Gateway 경로 라우트 누락 → Lambda 미도달

### 원인
API Gateway에 등록된 경로가 `ANY /formflex-dev` 하나뿐이었음.
실제 요청 경로는 `/formflex-dev/api/users/login`처럼 하위 경로를 포함하므로
라우트 매칭 실패 → API Gateway가 Lambda 호출 없이 자체적으로 `{"message":"Not Found"}` 반환.
(이 단계에서는 CloudWatch 로그도 생성되지 않음)

### 수정
API Gateway 콘솔 → 라우트 → 신규 경로 추가:

```
ANY /formflex-dev/{proxy+}    → 기존 Lambda 통합 연결
ANY /formflex-prod/{proxy+}   → 기존 Lambda 통합 연결
```

`{proxy+}` 가 없으면 하위 경로를 Lambda로 전달하지 않음.

---

## 버그 4: API Gateway CORS 설정 누락 → preflight 차단

### 원인
API Gateway HTTP API의 CORS 설정에서
`Access-Control-Allow-Headers`와 `Access-Control-Allow-Methods`가
아무것도 설정되어 있지 않았음.
프론트엔드가 `content-type: application/json` 헤더를 포함한
OPTIONS preflight 요청을 보내면 API Gateway가 차단.
이 단계에서도 Lambda까지 도달하지 못해 CloudWatch 로그가 남지 않음.

참고: API Gateway HTTP API의 CORS 설정이 활성화되면
Lambda에서 반환하는 CORS 헤더는 무시되고 API Gateway 설정이 우선 적용됨.

### 수정
API Gateway 콘솔 → 해당 API → CORS → 구성:

```
Access-Control-Allow-Origin:  *
Access-Control-Allow-Headers: content-type, accept, authorization, remember-me, x-requested-with
Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
Access-Control-Allow-Credentials: false  (Allow-Origin이 * 이면 true 불가)
```

---

## 재발 방지 체크리스트

- [ ] API Gateway에 새 Lambda 연결 시 `/{proxy+}` 라우트 반드시 추가
- [ ] API Gateway CORS 구성 시 Allow-Headers, Allow-Methods 필수 입력
- [ ] CI/CD 배포 스크립트의 `--function-name` 이 실제 연결된 Lambda 함수명과 일치하는지 확인
- [ ] `handler.js`의 `rawPath` 처리 시 stage prefix 포함 여부 고려