### PR TITLE
cicd 파이프라인 수정

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "cicd-preview",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "-p", "4321", "."],
+      "port": 4321
+    }
+  ]
+}

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -40,6 +40,13 @@ jobs:
       - name: 빌드 결과 확인
         run: ls -lh lambda.zip
 
+      - name: lambda.zip artifact 저장
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-zip
+          path: lambda.zip
+          retention-days: 1
+
   deploy-staging:
     name: 스테이징 배포 ($LATEST)
     needs: build
@@ -47,23 +54,10 @@ jobs:
     if: github.ref != 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Node.js 22 설정
-        uses: actions/setup-node@v4
+      - name: lambda.zip artifact 다운로드
+        uses: actions/download-artifact@v4
         with:
-          node-version: "22"
-
-      - name: 백엔드 프로덕션 의존성 설치
-        working-directory: backend
-        run: npm ci --omit=dev
-
-      - name: 배포용 압축 파일 생성
-        run: |
-          cd backend
-          zip -r ../lambda.zip . \
-             --exclude ".env" \
-             --exclude "*.git"
+          name: lambda-zip
 
       - name: AWS 자격 증명 설정
         uses: aws-actions/configure-aws-credentials@v4
@@ -89,6 +83,24 @@ jobs:
           aws lambda wait function-updated \
             --function-name formflex-dev
 
+      - name: 최신 Chromium Layer ARN 조회
+        run: |
+          LAYER_ARN=$(aws lambda list-layer-versions \
+            --layer-name formflex-chromium \
+            --query 'LayerVersions[0].LayerVersionArn' \
+            --output text)
+          echo "LAYER_ARN=${LAYER_ARN}" >> $GITHUB_ENV
+
+      - name: Lambda 함수 설정 업데이트
+        run: |
+          aws lambda update-function-configuration \
+            --function-name formflex-dev \
+            --memory-size 2048 \
+            --timeout 120 \
+            --layers${{env.LAYER_ARN}}
+          aws lambda wait function-updated \
+            --function-name formflex-dev
+
   deploy-prod:
     name: 프로덕션 배포 (prod alias)
     needs: build
@@ -96,23 +108,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v4
+      - name: lambda.zip artifact 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: lambda-zip
 
-      - name: Node.js 22 설정
+      - name: Node.js 22 설정(Chromium Layer 빋드용)
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: 프로덕션 의존성 패키지 설치
-        working-directory: backend
-        run: npm ci --omit=dev
-
-      - name: 배포용 압축 파일 생성
-        run: |
-          cd backend
-          zip -r ../lambda.zip . \
-             --exclude ".env" \
-             --exclude "*.git"
 
       - name: AWS 자격 증명 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -97,7 +97,7 @@ jobs:
             --function-name formflex-dev \
             --memory-size 2048 \
             --timeout 120 \
-            --layers${{env.LAYER_ARN}}
+            --layers ${{env.LAYER_ARN}}
           aws lambda wait function-updated \
             --function-name formflex-dev
 

--- a/cicd-pipeline.html
+++ b/cicd-pipeline.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FormFlex CI/CD Pipeline</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      padding: 40px;
+      min-width: 1100px;
+    }
+
+    /* ── PAGE HEADER ─────────────────────────────── */
+    .page-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 36px;
+      padding-bottom: 24px;
+      border-bottom: 1px solid #21262d;
+    }
+    .page-title { font-size: 22px; font-weight: 700; color: #f0f6fc; margin-bottom: 6px; }
+    .page-sub   { font-size: 13px; color: #8b949e; }
+    .badges     { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: 4px; }
+    .badge {
+      font-size: 11px; font-weight: 600;
+      border-radius: 20px; padding: 3px 11px;
+      border: 1px solid;
+    }
+
+    /* ── MAIN LAYOUT ─────────────────────────────── */
+    .layout {
+      display: flex;
+      gap: 0;
+      align-items: flex-start;
+    }
+    .col {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 20px;
+    }
+    .col-fe { width: 310px; border-right: 1px solid #21262d; }
+    .col-be { flex: 1; }
+
+    .col-title {
+      width: 100%;
+      font-size: 11px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.1em;
+      color: #8b949e;
+      margin-bottom: 18px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #21262d;
+      display: flex; align-items: center; gap: 7px;
+    }
+
+    /* ── CARDS ───────────────────────────────────── */
+    .card {
+      width: 100%;
+      border-radius: 8px;
+      padding: 12px 14px;
+      border: 1px solid #30363d;
+      background: #161b22;
+    }
+    .card.trigger  { background: #0c1929; border-color: #1f6feb; }
+    .card.build    { background: #1a1033; border-color: #6e40c9; }
+    .card.staging  { background: #051a26; border-color: #0ea5e9; }
+    .card.prod     { background: #071a12; border-color: #22c55e; }
+    .card.special  { background: #1c0e04; border-color: #f97316; }
+    .card.dark     { background: #111111; border-color: #444; }
+    .card.cond     { background: #1c1400; border-color: #9e6a03; }
+
+    .card-tag {
+      font-size: 10px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.07em;
+      margin-bottom: 4px;
+    }
+    .card.trigger .card-tag  { color: #58a6ff; }
+    .card.build   .card-tag  { color: #a371f7; }
+    .card.staging .card-tag  { color: #38bdf8; }
+    .card.prod    .card-tag  { color: #4ade80; }
+    .card.special .card-tag  { color: #fb923c; }
+    .card.dark    .card-tag  { color: #999; }
+    .card.cond    .card-tag  { color: #e3b341; }
+
+    .card-title {
+      font-size: 13px; font-weight: 600;
+      color: #f0f6fc; margin-bottom: 7px;
+    }
+
+    .items { display: flex; flex-direction: column; gap: 3px; }
+    .item  { font-size: 11.5px; color: #8b949e; line-height: 1.55; display: flex; gap: 6px; }
+    .item::before { content: '·'; color: #444; flex-shrink: 0; }
+
+    .items-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2px 20px;
+    }
+
+    .tags-row { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 4px; }
+    .tag {
+      font-size: 10px; font-family: monospace;
+      padding: 2px 7px; border-radius: 4px; border: 1px solid;
+    }
+    .tag.blue   { color: #58a6ff; border-color: #1f6feb55; background: #1f6feb10; }
+    .tag.green  { color: #4ade80; border-color: #22c55e55; background: #22c55e10; }
+    .tag.orange { color: #fb923c; border-color: #f9731655; background: #f9731610; }
+    .tag.cyan   { color: #38bdf8; border-color: #0ea5e955; background: #0ea5e910; }
+    .tag.gray   { color: #aaa;    border-color: #44444455; background: #44444410; }
+    .tag.yellow { color: #e3b341; border-color: #9e6a0355; background: #9e6a0310; }
+
+    /* ── ARROWS ──────────────────────────────────── */
+    .arrow {
+      display: flex; flex-direction: column; align-items: center;
+      padding: 2px 0;
+    }
+    .arrow .line { width: 2px; height: 18px; background: #30363d; }
+    .arrow .head {
+      width: 0; height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 7px solid #484f58;
+    }
+
+    /* ── FORK SPLIT ──────────────────────────────── */
+    .fork {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .fork-vline { width: 2px; height: 10px; background: #30363d; }
+    .fork-hline { width: 100%; height: 2px; background: #30363d; }
+    .fork-branches {
+      display: flex;
+      gap: 14px;
+      width: 100%;
+    }
+    .branch {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .branch-cond {
+      font-size: 10px; font-weight: 700;
+      padding: 3px 10px; border-radius: 20px;
+      border: 1px dashed;
+      margin-bottom: 8px;
+      text-align: center;
+      line-height: 1.4;
+    }
+    .branch-cond.staging { color: #38bdf8; border-color: #38bdf866; }
+    .branch-cond.prod    { color: #4ade80; border-color: #4ade8066; }
+
+    /* ── LEGEND ──────────────────────────────────── */
+    .legend {
+      margin-top: 36px;
+      padding-top: 18px;
+      border-top: 1px solid #21262d;
+      display: flex;
+      gap: 18px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .legend-lbl { font-size: 11px; color: #8b949e; font-weight: 600; }
+    .legend-item { display: flex; align-items: center; gap: 5px; font-size: 11px; }
+    .legend-dot  {
+      width: 10px; height: 10px;
+      border-radius: 2px; border: 1px solid; flex-shrink: 0;
+    }
+
+    /* ── CONCURRENCY CHIP ────────────────────────── */
+    .chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 10px; font-weight: 600;
+      padding: 2px 8px; border-radius: 20px;
+      border: 1px solid #9e6a0355; background: #9e6a0310;
+      color: #e3b341; margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+
+<!-- ══════════ PAGE HEADER ══════════ -->
+<div class="page-header">
+  <div>
+    <div class="page-title">🚀 FormFlex CI/CD Pipeline</div>
+    <div class="page-sub">GitHub Actions (Backend) · Vercel (Frontend) · AWS Lambda + S3 · Region: ap-northeast-2</div>
+    <div class="badges" style="margin-top:8px;">
+      <span class="badge" style="color:#4ade80;border-color:#22c55e44;background:#22c55e0d;">● Backend: GitHub Actions</span>
+      <span class="badge" style="color:#fff;border-color:#44444466;background:#44444411;">▲ Frontend: Vercel</span>
+      <span class="badge" style="color:#FF9900;border-color:#FF990044;background:#FF99000d;">☁ AWS Lambda (Node 22)</span>
+    </div>
+  </div>
+  <div style="font-size:12px;color:#8b949e;text-align:right;line-height:2;">
+    <div>.github/workflows/depoly.yml</div>
+    <div>serverless.yml · vercel.json</div>
+  </div>
+</div>
+
+
+<!-- ══════════ TWO-COLUMN LAYOUT ══════════ -->
+<div class="layout">
+
+  <!-- ╔══════════ FRONTEND COLUMN ══════════╗ -->
+  <div class="col col-fe">
+    <div class="col-title">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <rect x="2" y="3" width="20" height="14" rx="2"/>
+        <path d="M8 21h8M12 17v4"/>
+      </svg>
+      Frontend &nbsp;(Vercel Auto-Deploy)
+    </div>
+
+    <!-- Trigger -->
+    <div class="card trigger">
+      <div class="card-tag">Trigger</div>
+      <div class="card-title">git push (모든 브랜치)</div>
+      <div class="items">
+        <div class="item">GitHub ↔ Vercel 연동 훅</div>
+        <div class="item">별도 GitHub Actions 없음</div>
+        <div class="item">Vercel이 자동으로 감지 · 배포</div>
+      </div>
+    </div>
+
+    <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+    <!-- Vercel Build -->
+    <div class="card dark">
+      <div class="card-tag">Build</div>
+      <div class="card-title">Vercel Build</div>
+      <div class="items">
+        <div class="item">vite build (TypeScript 컴파일)</div>
+        <div class="item">정적 번들 최적화</div>
+        <div class="item">vercel.json SPA rewrite 적용</div>
+      </div>
+    </div>
+
+    <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+    <!-- Condition -->
+    <div class="card cond">
+      <div class="card-tag">Branch Condition</div>
+      <div class="card-title" style="text-align:center;">어느 브랜치?</div>
+    </div>
+
+    <!-- Fork -->
+    <div class="fork">
+      <div class="fork-vline"></div>
+      <div class="fork-hline"></div>
+      <div class="fork-branches">
+
+        <!-- feature branch -->
+        <div class="branch">
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+          <div class="branch-cond staging">feature / dev</div>
+          <div class="card staging" style="width:100%;">
+            <div class="card-tag">Preview Deploy</div>
+            <div class="card-title">Preview URL 생성</div>
+            <div class="items">
+              <div class="item">임시 도메인 자동 발급</div>
+              <div class="item">PR · 브랜치 미리보기</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag gray">▲ Vercel Preview</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- main branch -->
+        <div class="branch">
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+          <div class="branch-cond prod">main</div>
+          <div class="card prod" style="width:100%;">
+            <div class="card-tag">Production Deploy</div>
+            <div class="card-title">formflex.site 배포</div>
+            <div class="items">
+              <div class="item">글로벌 CDN 엣지 배포</div>
+              <div class="item">캐시 자동 갱신</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag green">▲ Vercel Production</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <!-- ╚══════════ /FRONTEND ══════════╝ -->
+
+
+  <!-- ╔══════════ BACKEND COLUMN ══════════╗ -->
+  <div class="col col-be">
+    <div class="col-title">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+      </svg>
+      Backend &nbsp;(GitHub Actions → AWS Lambda)
+    </div>
+
+    <!-- ① Trigger -->
+    <div class="card trigger">
+      <div class="card-tag">Trigger — on: push (경로 필터)</div>
+      <div class="card-title">특정 경로 변경 시에만 실행</div>
+      <div class="tags-row">
+        <span class="tag blue">backend/**</span>
+        <span class="tag blue">index.js</span>
+        <span class="tag blue">.github/workflows/**</span>
+        <span class="tag blue">serverless.yml</span>
+      </div>
+      <div class="items" style="margin-top:7px;">
+        <div class="item">runs-on: ubuntu-latest</div>
+      </div>
+      <div class="chip">⚙ concurrency: lambda-deploy · cancel-in-progress: false (큐 직렬 처리)</div>
+    </div>
+
+    <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+    <!-- ② Job 1: Build -->
+    <div class="card build">
+      <div class="card-tag">Job 1 — 빌드 검증 &nbsp;(모든 브랜치 공통, 항상 실행)</div>
+      <div class="card-title">Build &amp; Zip</div>
+      <div class="items items-grid">
+        <div class="item">actions/checkout@v4</div>
+        <div class="item">actions/setup-node@v4 (v22)</div>
+        <div class="item">npm ci --omit=dev</div>
+        <div class="item">lambda.zip 생성</div>
+        <div class="item">.env · .git 파일 제외</div>
+        <div class="item">ls -lh 파일 크기 검증</div>
+      </div>
+    </div>
+
+    <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+    <!-- ③ Branch Condition -->
+    <div class="card cond">
+      <div class="card-tag">Branch Condition</div>
+      <div class="card-title" style="text-align:center;">어느 브랜치로 푸시했나요?</div>
+    </div>
+
+    <!-- ④ Fork -->
+    <div class="fork">
+      <div class="fork-vline"></div>
+      <div class="fork-hline"></div>
+      <div class="fork-branches">
+
+        <!-- ── STAGING BRANCH ── -->
+        <div class="branch">
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+          <div class="branch-cond staging">if: github.ref != 'refs/heads/main'</div>
+
+          <!-- Staging Setup -->
+          <div class="card staging" style="width:100%;">
+            <div class="card-tag">Job 2 — 스테이징 배포</div>
+            <div class="card-title">Staging Setup</div>
+            <div class="items">
+              <div class="item">actions/checkout@v4</div>
+              <div class="item">Node.js 22 설정</div>
+              <div class="item">npm ci --omit=dev</div>
+              <div class="item">lambda.zip 재생성</div>
+              <div class="item">aws-actions/configure-aws-credentials@v4</div>
+            </div>
+          </div>
+
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+          <!-- S3 + Lambda Deploy -->
+          <div class="card staging" style="width:100%;">
+            <div class="card-tag">S3 Upload → Lambda 배포</div>
+            <div class="card-title">formflex-dev 업데이트</div>
+            <div class="items">
+              <div class="item">aws s3 cp lambda.zip</div>
+              <div class="item">→ s3://bucket/deploy-staging/</div>
+              <div class="item">update-function-code</div>
+              <div class="item">architectures: x86_64</div>
+              <div class="item">lambda wait function-updated</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag cyan">☁ formflex-dev ($LATEST)</span>
+            </div>
+          </div>
+        </div>
+        <!-- ── /STAGING ── -->
+
+
+        <!-- ── PRODUCTION BRANCH ── -->
+        <div class="branch">
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+          <div class="branch-cond prod">if: github.ref == 'refs/heads/main'</div>
+
+          <!-- Prod Setup -->
+          <div class="card prod" style="width:100%;">
+            <div class="card-tag">Job 3 — 프로덕션 배포 &nbsp;①&nbsp;Setup</div>
+            <div class="card-title">Lambda Zip 준비</div>
+            <div class="items">
+              <div class="item">actions/checkout@v4</div>
+              <div class="item">Node.js 22 설정</div>
+              <div class="item">npm ci --omit=dev</div>
+              <div class="item">lambda.zip 재생성 (.env · .git 제외)</div>
+              <div class="item">aws-actions/configure-aws-credentials@v4</div>
+            </div>
+          </div>
+
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+          <!-- Chromium Layer (특수 스텝) -->
+          <div class="card special" style="width:100%;">
+            <div class="card-tag">② &nbsp;Chromium Lambda Layer 빌드 &nbsp;⚡ 특수 스텝</div>
+            <div class="card-title">Puppeteer PDF Layer 패키징</div>
+            <div class="items">
+              <div class="item">mkdir chromium-layer/nodejs</div>
+              <div class="item">@sparticuz/chromium@147 설치</div>
+              <div class="item">puppeteer-core@24 설치</div>
+              <div class="item">chromium-layer.zip 패키징</div>
+              <div class="item">aws s3 cp → s3://bucket/layers/</div>
+              <div class="item">publish-layer-version</div>
+              <div class="item">LAYER_ARN → $GITHUB_ENV 저장</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag orange">☁ formflex-chromium (Layer)</span>
+              <span class="tag orange">nodejs22.x · x86_64</span>
+            </div>
+          </div>
+
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+          <!-- Lambda Code Deploy -->
+          <div class="card prod" style="width:100%;">
+            <div class="card-tag">③ &nbsp;Lambda 코드 배포 + 설정</div>
+            <div class="card-title">formflex-prod 업데이트</div>
+            <div class="items">
+              <div class="item">aws s3 cp → s3://bucket/deploy/lambda.zip</div>
+              <div class="item">update-function-code (x86_64)</div>
+              <div class="item">lambda wait function-updated ①</div>
+              <div class="item">update-function-configuration</div>
+              <div class="item">handler: handler.handler</div>
+              <div class="item">memory-size: 2048 MB</div>
+              <div class="item">timeout: 120 s</div>
+              <div class="item">layers: [$LAYER_ARN] ← Chromium 연결</div>
+              <div class="item">lambda wait function-updated ②</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag green">☁ formflex-prod</span>
+              <span class="tag green">ap-northeast-2</span>
+            </div>
+          </div>
+
+          <div class="arrow"><div class="line"></div><div class="head"></div></div>
+
+          <!-- Publish & Alias -->
+          <div class="card prod" style="width:100%;">
+            <div class="card-tag">④ &nbsp;버전 Publish &amp; prod alias 갱신</div>
+            <div class="card-title">무중단 트래픽 전환</div>
+            <div class="items">
+              <div class="item">publish-version → VERSION 번호 추출</div>
+              <div class="item">update-alias --name prod</div>
+              <div class="item">prod alias → 새 Lambda 버전 연결</div>
+              <div class="item">기존 버전 즉시 대체 (Zero-downtime)</div>
+            </div>
+            <div class="tags-row">
+              <span class="tag green">✓ prod alias 갱신 완료</span>
+            </div>
+          </div>
+        </div>
+        <!-- ── /PRODUCTION ── -->
+
+      </div>
+    </div>
+
+  </div>
+  <!-- ╚══════════ /BACKEND ══════════╝ -->
+
+</div>
+
+
+<!-- ══════════ LEGEND ══════════ -->
+<div class="legend">
+  <span class="legend-lbl">범례</span>
+
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#0c1929;border-color:#1f6feb;"></div>
+    <span style="color:#58a6ff;">Trigger</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#1a1033;border-color:#6e40c9;"></div>
+    <span style="color:#a371f7;">Build Job</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#051a26;border-color:#0ea5e9;"></div>
+    <span style="color:#38bdf8;">Staging</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#071a12;border-color:#22c55e;"></div>
+    <span style="color:#4ade80;">Production</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#1c0e04;border-color:#f97316;"></div>
+    <span style="color:#fb923c;">Chromium Layer (특수 스텝)</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#111;border-color:#444;"></div>
+    <span style="color:#aaa;">Vercel Build</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-dot" style="background:#1c1400;border-color:#9e6a03;"></div>
+    <span style="color:#e3b341;">Branch Condition</span>
+  </div>
+
+  <div style="margin-left:auto;font-size:11px;color:#484f58;">
+    FormFlex CI/CD · 2026 · .github/workflows/depoly.yml
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION

## 어떤 문제를 고쳤나요?

CI/CD 파이프라인에 두 가지 구조적 문제가 있었습니다.

**1. lambda.zip 중복 빌드 (GitHub Actions job 격리 미이해)**

GitHub Actions의 각 job은 독립된 Ubuntu VM에서 실행됩니다.
즉, `build` job이 종료되는 순간 해당 VM도 함께 삭제되어
생성된 `lambda.zip`도 사라집니다.

`needs: build`는 단순히 "Job 1이 성공한 후 실행해라"는
실행 순서를 보장할 뿐, 파일을 넘겨주지 않습니다.

그 결과 `deploy-staging`, `deploy-prod`는 각자 새로운 VM에서
`checkout → npm ci → zip` 과정을 처음부터 다시 반복하고 있었습니다.
`build` job은 빌드 성공 여부만 확인하고 결과물을 버리는,
**사실상 아무런 역할도 하지 않는 job**이었습니다.

```
# 변경 전 — zip이 3번 실행됨
build job        → checkout → npm ci → zip (🗑️ VM 종료 시 사라짐)
deploy-staging   → checkout → npm ci → zip → S3 → Lambda 배포
deploy-prod      → checkout → npm ci → zip → S3 → Lambda 배포

# 변경 후 — zip은 1번만
build job        → checkout → npm ci → zip → artifact 저장 ✅
deploy-staging   → artifact 다운로드 → S3 → Lambda 배포
deploy-prod      → artifact 다운로드 → S3 → Lambda 배포
```

**2. staging(formflex-dev)은 동작하는데 prod(formflex-prod)는 안 되는 기능 존재**

`deploy-prod`에는 있고 `deploy-staging`에는 없는 설정이 두 가지 있었습니다.

**① Chromium Lambda Layer**

PDF 자동 리포트 이메일 기능은 Puppeteer로 분석 페이지를 렌더링해
PDF로 변환 후 발송합니다. Puppeteer가 필요로 하는 Chromium 바이너리는
Lambda Layer를 통해서만 제공됩니다.

`deploy-prod`는 매 배포마다 Chromium Layer를 빌드하고 `formflex-prod`에
연결하지만, `deploy-staging`에는 이 과정이 없었습니다.

그 결과 staging에서 목표 응답 수에 도달해도 이메일이 발송되지 않았고,
에러는 `answerSave.js`의 try-catch에 잡혀 응답은 201을 반환하기 때문에
**겉으로는 정상처럼 보이나 실제로는 조용히 실패**하고 있었습니다.

```
# staging에서 목표 응답 수 달성 시
응답 저장 (DB) ✅
sendPdfReportEmail() 호출 ✅
chromium.executablePath() → Lambda Layer 없음 💥
try-catch에 포착
→ console.error('[EMAIL_REPORT] 발송 실패') 로그만 남김
→ 응답자에게는 그냥 201 OK 반환 (이메일 미발송)
```

**② memory / timeout 설정 누락**

`deploy-prod`는 `update-function-configuration`으로
memory 2048MB, timeout 120s를 명시적으로 적용하지만
`deploy-staging`에는 이 설정이 없어 Lambda 기본값이 유지되었습니다.
prod에서 문제없이 동작하던 기능이 staging에서는 timeout으로
실패할 수 있는 환경이었습니다.

## 무엇을 바꿨나요?

**`build` job**
- `actions/upload-artifact@v4` 추가
  → `lambda.zip`을 artifact로 저장해 이후 job에서 재사용 (retention: 1일)

**`deploy-staging` job**
- `checkout` · `Node.js 설정` · `npm ci` · `zip` 4개 step 제거
  → `actions/download-artifact@v4`로 대체
- `aws lambda list-layer-versions`로 기존 배포된 Chromium Layer 최신 ARN 조회
  → Chromium Layer를 재빌드 없이 재사용
- `update-function-configuration` 추가
  → memory 2048MB, timeout 120s, Chromium Layer 연결

**`deploy-prod` job**
- `checkout` · `npm ci` · `zip` 3개 step 제거
  → `actions/download-artifact@v4` + `setup-node` (Chromium Layer 빌드용 npm 필요)로 대체

## 변경 전 / 후

| | 변경 전 | 변경 후 |
|---|---|---|
| npm ci + zip 실행 횟수 | 3회 | 1회 |
| build job 역할 | 사실상 없음 | zip 생성 후 artifact 전달 |
| staging Chromium Layer | ❌ 미연결 | ✅ 기존 Layer 재사용 |
| staging memory / timeout | Lambda 기본값 | prod와 동일 (2048MB / 120s) |
| staging PDF 자동 리포트 | ❌ 조용히 실패 | ✅ 정상 동작 |
| prod PDF 자동 리포트 | ✅ 정상 동작 | ✅ 정상 동작 (유지) |

## 관련 이슈

- 이슈 링크

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment pipeline to reuse pre-built artifacts across staging and production environments, improving deployment efficiency and consistency.
  * Added VS Code debugging configuration for local development.
  * Added CI/CD pipeline documentation and visualization for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->